### PR TITLE
Fix "why" message for circular reference inequality

### DIFF
--- a/test/why.js
+++ b/test/why.js
@@ -628,5 +628,21 @@ test('circular references', function (t) {
 		'two objects with different circular references are not equal'
 	);
 
+	var e = {};
+	var f = {};
+	e.e = e;
+	f.e = null;
+	t.equal(
+		isEqualWhy(e, f),
+		'first argument has a circular reference at key "e"; second does not',
+		'two objects without corresponding circular references are not equal'
+	);
+
+	t.equal(
+		isEqualWhy(f, e),
+		'second argument has a circular reference at key "e"; first does not',
+		'two objects without corresponding circular references are not equal'
+	);
+
 	t.end();
 });

--- a/why.js
+++ b/why.js
@@ -272,7 +272,7 @@ module.exports = function whyNotEqual(value, other) {
 				otherKeyIsRecursive = other[key] && other[key][key] === other;
 				if (valueKeyIsRecursive !== otherKeyIsRecursive) {
 					if (valueKeyIsRecursive) { return 'first argument has a circular reference at key "' + key + '"; second does not'; }
-					return 'second argument has a circular reference at key "' + key + '"; second does not';
+					return 'second argument has a circular reference at key "' + key + '"; first does not';
 				}
 				if (!valueKeyIsRecursive && !otherKeyIsRecursive) {
 					keyWhy = whyNotEqual(value[key], other[key]);


### PR DESCRIPTION
Name the correct argument: `second => first`.

I deliberately didn't change the [other instance](https://github.com/jmm/is-equal/blob/65002c0dc492e8b70dc99c5a64f0ab85522a3892/why.js#L292) -- ~~will explain why in other PR~~ see #13.