### PR TITLE
Unreachable code in circular reference check?

### DIFF
--- a/why.js
+++ b/why.js
@@ -283,21 +283,7 @@ module.exports = function whyNotEqual(value, other) {
 			}
 		}
 		for (key in other) {
-			if (has(other, key)) {
-				if (!has(value, key)) { return 'second argument has key "' + key + '"; first does not'; }
-				valueKeyIsRecursive = value[key] && value[key][key] === value;
-				otherKeyIsRecursive = other[key] && other[key][key] === other;
-				if (valueKeyIsRecursive !== otherKeyIsRecursive) {
-					if (valueKeyIsRecursive) { return 'first argument has a circular reference at key "' + key + '"; second does not'; }
-					return 'second argument has a circular reference at key "' + key + '"; second does not';
-				}
-				if (!valueKeyIsRecursive && !otherKeyIsRecursive) {
-					keyWhy = whyNotEqual(other[key], value[key]);
-					if (keyWhy !== '') {
-						return 'value at key "' + key + '" differs: ' + keyWhy;
-					}
-				}
-			}
+			if (has(other, key) && !has(value, key)) { return 'second argument has key "' + key + '"; first does not'; }
 		}
 		return '';
 	}


### PR DESCRIPTION
When I was doing #12 I started looking at deduplicating the [circular reference checks](https://github.com/ljharb/is-equal/blob/adc9c0a5deaf43390f080a177c3935b8089307b6/why.js#L268-L301) but got bogged down with code style issues. Then I wondered if all of that code is actually reachable. I tried to run the coverage report but it errored out for me. But as demonstrated by this PR, the chunk I'm referring to is not covered; with this change existing tests (and those I add in #12) pass. Is there a situation I haven't thought of where this would be reachable?
