### PR TITLE
[New] compare `.toString`, `.valueOf`, and `[Symbol.toPrimitive]` completions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,7 +10,8 @@
 		"id-length": [2, { "min": 1, "max": 23 }],
 		"max-depth": [2, 5],
 		"max-len": 0,
-		"max-lines-per-function": [2, { "max": 250 }],
+		"max-lines-per-function": [2, { "max": 300 }],
+		"max-params": 0,
 		"max-statements": [1, 10],
 		"max-statements-per-line": [2, { "max": 2 }],
 		"new-cap": [2, { "capIsNewExceptions": ["BigInt"] }],
@@ -28,6 +29,7 @@
 			"files": "test/**",
 			"rules": {
 				"func-name-matching": 0,
+				"no-throw-literal": 0,
 				"prefer-regex-literals": 0,
 			},
 		},

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
 	],
 	"dependencies": {
 		"es-get-iterator": "^1.1.3",
+		"es-to-primitive": "^1.2.1",
 		"functions-have-names": "^1.2.3",
 		"has": "^1.0.3",
 		"has-bigints": "^1.0.2",

--- a/test/native.js
+++ b/test/native.js
@@ -311,6 +311,62 @@ test('bigints', { skip: !hasBigInts }, function (t) {
 	t.end();
 });
 
+test('toPrimitive', function (t) {
+	t.test('gracefully handles error throwing', function (mt) {
+		var toStringThrow = {
+			toString: function () { throw new Error(); }
+		};
+		var valueOfThrow = {
+			valueOf: function () { throw new Error(); }
+		};
+		var noThrow = {};
+
+		mt.equal(isEqual(toStringThrow, noThrow), false, 'first argument toPrimitive throws, second does not');
+		mt.equal(isEqual(noThrow, toStringThrow), false, 'second argument toPrimitive throws, first does not');
+		mt.equal(isEqual(valueOfThrow, noThrow), false, 'first argument toPrimitive throws, second does not');
+		mt.equal(isEqual(noThrow, valueOfThrow), false, 'second argument toPrimitive throws; first does not');
+
+		mt.end();
+	});
+
+	t.test('toPrimitive strings', function (mt) {
+		var foo1 = {
+			toString: function () { return 'foo'; }
+		};
+		var foo2 = {
+			toString: function () { return 'foo'; }
+		};
+		var bar = {
+			toString: function () { return 'bar'; }
+		};
+
+		mt.equal(isEqual(foo1, foo2), true, 'both argument toPrimitive values are equal');
+		mt.equal(isEqual(foo1, bar), false, 'argument toPrimitive values are not equal');
+		mt.equal(isEqual(bar, foo1), false, 'argument toPrimitive values are not equal');
+
+		mt.end();
+	});
+
+	t.test('toPrimitive numbers', function (mt) {
+		var value1 = {
+			valueOf: function () { return 1; }
+		};
+		var alsoValue1 = {
+			valueOf: function () { return 1; }
+		};
+		var value2 = {
+			valueOf: function () { return 2; }
+		};
+
+		mt.equal(isEqual(value1, alsoValue1), true, 'both argument toPrimitive values are equal');
+		mt.equal(isEqual(value1, value2), false, 'argument toPrimitive values are not equal');
+		mt.equal(isEqual(value2, value1), false, 'argument toPrimitive values are not equal');
+
+		mt.end();
+	});
+	t.end();
+});
+
 var genericIterator = function (obj) {
 	var entries = objectEntries(obj);
 	return function iterator() {


### PR DESCRIPTION
If `val` or `other` are objects:
- Compares `val.toString()` and `other.toString()`
- Compares `val.valueOf()` and `other.valueOf()`
- Uses `es-to-primitive` to perform the above checks, with two separate hints (`String` and `Number`)
- Also considers that `toString` and `valueOf` can throw, and makes sure both or neither arguments throw

Test plan:
- Adds test coverage for all of the above
- tests + lint pass, test coverage does not regress